### PR TITLE
Fixes for pre- task list navigation and cleanup.

### DIFF
--- a/app/navigation/PreTaskListNavigator.scala
+++ b/app/navigation/PreTaskListNavigator.scala
@@ -27,25 +27,25 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class PreTaskListNavigator @Inject() () extends Navigator {
 
-  override val normalRoutes: PartialFunction[Page, UserAnswers => Option[Call]] = {
-    case LocalReferenceNumberPage => ua => Some(OfficeOfDepartureController.onPageLoad(ua.lrn, NormalMode))
-    case OfficeOfDeparturePage    => ua => Some(ProcedureTypeController.onPageLoad(ua.lrn, NormalMode))
-    case ProcedureTypePage        => ua => Some(DeclarationTypeController.onPageLoad(ua.lrn, NormalMode))
-    case DeclarationTypePage      => ua => declarationTypeRoute(ua)
-    case TIRCarnetReferencePage   => ua => Some(SecurityDetailsTypeController.onPageLoad(ua.lrn, NormalMode))
+  override val normalRoutes: PartialFunction[Page, UserAnswers => Option[Call]] = routes(NormalMode)
+
+  override val checkRoutes: PartialFunction[Page, UserAnswers => Option[Call]] = routes(CheckMode)
+
+  private def routes(mode: Mode): PartialFunction[Page, UserAnswers => Option[Call]] = {
+    case LocalReferenceNumberPage => ua => Some(OfficeOfDepartureController.onPageLoad(ua.lrn, mode))
+    case OfficeOfDeparturePage    => ua => Some(ProcedureTypeController.onPageLoad(ua.lrn, mode))
+    case ProcedureTypePage        => ua => Some(DeclarationTypeController.onPageLoad(ua.lrn, mode))
+    case DeclarationTypePage      => ua => declarationTypeRoute(ua, mode)
+    case TIRCarnetReferencePage   => ua => Some(SecurityDetailsTypeController.onPageLoad(ua.lrn, mode))
     case SecurityDetailsTypePage  => ua => Some(CheckYourAnswersController.onPageLoad(ua.lrn))
   }
 
-  override val checkRoutes: PartialFunction[Page, UserAnswers => Option[Call]] = {
-    case _ => ua => Some(CheckYourAnswersController.onPageLoad(ua.lrn))
-  }
-
-  private def declarationTypeRoute(ua: UserAnswers): Option[Call] =
+  private def declarationTypeRoute(ua: UserAnswers, mode: Mode): Option[Call] =
     (ua.get(ProcedureTypePage), ua.get(DeclarationTypePage)) match {
       case (Some(ProcedureType.Normal), Some(DeclarationType.Option4)) =>
-        Some(TIRCarnetReferenceController.onPageLoad(ua.lrn, NormalMode))
+        Some(TIRCarnetReferenceController.onPageLoad(ua.lrn, mode))
       case _ =>
-        Some(SecurityDetailsTypeController.onPageLoad(ua.lrn, NormalMode))
+        Some(SecurityDetailsTypeController.onPageLoad(ua.lrn, mode))
     }
 
 }

--- a/app/pages/preTaskList/DeclarationTypePage.scala
+++ b/app/pages/preTaskList/DeclarationTypePage.scala
@@ -16,14 +16,12 @@
 
 package pages.preTaskList
 
-import derivable.DeriveNumberOfGuarantees
-import models.{DeclarationType, GuaranteeType, Index, UserAnswers}
+import models.DeclarationType.Option4
+import models.{DeclarationType, UserAnswers}
 import pages.QuestionPage
-import pages.guaranteeDetails.GuaranteeTypePage
 import play.api.libs.json.JsPath
-import queries.GuaranteesQuery
 
-import scala.util.{Success, Try}
+import scala.util.Try
 
 case object DeclarationTypePage extends QuestionPage[DeclarationType] {
 
@@ -31,34 +29,9 @@ case object DeclarationTypePage extends QuestionPage[DeclarationType] {
 
   override def toString: String = "declarationType"
 
-  override def cleanup(value: Option[DeclarationType], userAnswers: UserAnswers): Try[UserAnswers] = {
-    import DeclarationType.{Option1, Option2, Option3, Option4}
-
-    val amountOfGuarantees = userAnswers.get(DeriveNumberOfGuarantees).getOrElse(0)
-
-    lazy val removeAllGuarantees: Try[UserAnswers] = (0 until userAnswers.get(DeriveNumberOfGuarantees).getOrElse(0)).foldLeft(Try(userAnswers))(
-      (ua, _) => ua.flatMap(_.remove(GuaranteesQuery(Index(0))))
-    )
-
-    lazy val findTirGuaranteeType: Option[Int] = (0 until amountOfGuarantees).find {
-      index =>
-        userAnswers.get(GuaranteeTypePage(Index(index))).contains(GuaranteeType.TIR)
-    }
-
+  override def cleanup(value: Option[DeclarationType], userAnswers: UserAnswers): Try[UserAnswers] =
     value match {
-      case Some(Option1 | Option2 | Option3) =>
-        findTirGuaranteeType match {
-          case Some(_) => removeAllGuarantees
-          case None    => Success(userAnswers)
-        }
-
-      case Some(Option4) =>
-        findTirGuaranteeType match {
-          case Some(_) => Success(userAnswers)
-          case None    => removeAllGuarantees
-        }
-
-      case _ => Success(userAnswers)
+      case Some(option) if option != Option4 => userAnswers.remove(TIRCarnetReferencePage)
+      case _                                 => super.cleanup(value, userAnswers)
     }
-  }
 }

--- a/app/pages/preTaskList/ProcedureTypePage.scala
+++ b/app/pages/preTaskList/ProcedureTypePage.scala
@@ -19,7 +19,6 @@ package pages.preTaskList
 import models.ProcedureType.Simplified
 import models.{ProcedureType, UserAnswers}
 import pages.QuestionPage
-import pages.generalInformation.PreLodgeDeclarationPage
 import play.api.libs.json.JsPath
 
 import scala.util.Try
@@ -32,7 +31,7 @@ case object ProcedureTypePage extends QuestionPage[ProcedureType] {
 
   override def cleanup(value: Option[ProcedureType], userAnswers: UserAnswers): Try[UserAnswers] =
     value match {
-      case Some(Simplified) => userAnswers.remove(PreLodgeDeclarationPage)
+      case Some(Simplified) => userAnswers.remove(TIRCarnetReferencePage)
       case _                => super.cleanup(value, userAnswers)
     }
 

--- a/test/pages/AddAdministrativeReferencePageSpec.scala
+++ b/test/pages/AddAdministrativeReferencePageSpec.scala
@@ -16,16 +16,12 @@
 
 package pages
 
-import models.{Index, UserAnswers}
+import models.UserAnswers
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages.addItems.{AddAdministrativeReferencePage, AddExtraInformationPage, PreviousReferencePage, ReferenceTypePage}
 import pages.behaviours.PageBehaviours
 
-class AddAdministrativeReferencePageSpec extends PageBehaviours with ScalaCheckPropertyChecks {
-
-  private val index          = Index(0)
-  private val referenceIndex = Index(0)
+class AddAdministrativeReferencePageSpec extends PageBehaviours {
 
   "AddAdministrativeReferencePage" - {
 

--- a/test/pages/AddExtraInformationPageSpec.scala
+++ b/test/pages/AddExtraInformationPageSpec.scala
@@ -16,16 +16,13 @@
 
 package pages
 
-import models.{Index, UserAnswers}
+import models.UserAnswers
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages.addItems.{AddExtraInformationPage, ExtraInformationPage}
 import pages.behaviours.PageBehaviours
 
-class AddExtraInformationPageSpec extends PageBehaviours with ScalaCheckPropertyChecks {
+class AddExtraInformationPageSpec extends PageBehaviours {
 
-  val itemIndex: Index              = Index(0)
-  val referenceIndex: Index         = Index(0)
   val page: AddExtraInformationPage = AddExtraInformationPage(itemIndex, referenceIndex)
 
   "AddExtraInformationPage" - {

--- a/test/pages/ExtraInformationPageSpec.scala
+++ b/test/pages/ExtraInformationPageSpec.scala
@@ -16,20 +16,17 @@
 
 package pages
 
-import models.Index
 import pages.addItems.ExtraInformationPage
 import pages.behaviours.PageBehaviours
 
 class ExtraInformationPageSpec extends PageBehaviours {
 
-  private val index = Index(0)
-
   "ExtraInformationPage" - {
 
-    beRetrievable[String](ExtraInformationPage(index, index))
+    beRetrievable[String](ExtraInformationPage(index, referenceIndex))
 
-    beSettable[String](ExtraInformationPage(index, index))
+    beSettable[String](ExtraInformationPage(index, referenceIndex))
 
-    beRemovable[String](ExtraInformationPage(index, index))
+    beRemovable[String](ExtraInformationPage(index, referenceIndex))
   }
 }

--- a/test/pages/ItemDescriptionPageSpec.scala
+++ b/test/pages/ItemDescriptionPageSpec.scala
@@ -20,8 +20,6 @@ import pages.behaviours.PageBehaviours
 
 class ItemDescriptionPageSpec extends PageBehaviours {
 
-  private val index = models.Index(0)
-
   "ItemDescriptionPage" - {
 
     beRetrievable[String](ItemDescriptionPage(index))

--- a/test/pages/ItemTotalGrossMassPageSpec.scala
+++ b/test/pages/ItemTotalGrossMassPageSpec.scala
@@ -20,8 +20,6 @@ import pages.behaviours.PageBehaviours
 
 class ItemTotalGrossMassPageSpec extends PageBehaviours {
 
-  private val index = models.Index(0)
-
   "ItemTotalGrossMassPage" - {
 
     beRetrievable[Double](ItemTotalGrossMassPage(index))

--- a/test/pages/PreviousReferencePageSpec.scala
+++ b/test/pages/PreviousReferencePageSpec.scala
@@ -16,14 +16,10 @@
 
 package pages
 
-import models.Index
 import pages.addItems.PreviousReferencePage
 import pages.behaviours.PageBehaviours
 
 class PreviousReferencePageSpec extends PageBehaviours {
-
-  private val index          = Index(0)
-  private val referenceIndex = Index(0)
 
   "PreviousReferencePage" - {
 

--- a/test/pages/ReferenceTypePageSpec.scala
+++ b/test/pages/ReferenceTypePageSpec.scala
@@ -16,14 +16,10 @@
 
 package pages
 
-import models.Index
 import pages.addItems.ReferenceTypePage
 import pages.behaviours.PageBehaviours
 
 class ReferenceTypePageSpec extends PageBehaviours {
-
-  private val index          = Index(0)
-  private val referenceIndex = Index(0)
 
   "ReferenceTypePage" - {
 

--- a/test/pages/TIRCarnetReferencePageSpec.scala
+++ b/test/pages/TIRCarnetReferencePageSpec.scala
@@ -16,14 +16,10 @@
 
 package pages
 
-import models.Index
 import pages.addItems.TIRCarnetReferencePage
 import pages.behaviours.PageBehaviours
 
 class TIRCarnetReferencePageSpec extends PageBehaviours {
-
-  private val itemIndex     = Index(0)
-  private val documentIndex = Index(0)
 
   "TIRCarnetReferencePage" - {
 

--- a/test/pages/addItems/AddAnotherPreviousAdministrativeReferencePageSpec.scala
+++ b/test/pages/addItems/AddAnotherPreviousAdministrativeReferencePageSpec.scala
@@ -16,13 +16,10 @@
 
 package pages.addItems
 
-import models.Index
 import pages.behaviours.PageBehaviours
 
 class AddAnotherPreviousAdministrativeReferencePageSpec extends PageBehaviours {
 
-  val index          = Index(0)
-  val referenceIndex = Index(0)
   "AddAnotherPreviousAdministrativeReferencePage" - {
 
     beRetrievable[Boolean](AddAnotherPreviousAdministrativeReferencePage(index))

--- a/test/pages/addItems/ConfirmRemovePreviousAdministrativeReferencePageSpec.scala
+++ b/test/pages/addItems/ConfirmRemovePreviousAdministrativeReferencePageSpec.scala
@@ -16,10 +16,9 @@
 
 package pages.addItems
 
-import models.Index
 import pages.behaviours.PageBehaviours
 
-class ConfirmRemovePreviousAdministrativeReferencePageSpec(index: Index, referenceIndex: Index) extends PageBehaviours {
+class ConfirmRemovePreviousAdministrativeReferencePageSpec extends PageBehaviours {
 
   "ConfirmRemovePreviousAdministrativeReferencePage" - {
 

--- a/test/pages/addItems/DocumentExtraInformationPageSpec.scala
+++ b/test/pages/addItems/DocumentExtraInformationPageSpec.scala
@@ -16,10 +16,9 @@
 
 package pages.addItems
 
-import models.Index
 import pages.behaviours.PageBehaviours
 
-class DocumentExtraInformationPageSpec(index: Index, documentIndex: Index) extends PageBehaviours {
+class DocumentExtraInformationPageSpec extends PageBehaviours {
 
   "DocumentExtraInformationPage" - {
 

--- a/test/pages/addItems/DocumentTypePageSpec.scala
+++ b/test/pages/addItems/DocumentTypePageSpec.scala
@@ -16,14 +16,9 @@
 
 package pages.addItems
 
-import generators.UserAnswersGenerator
-import models.Index
 import pages.behaviours.PageBehaviours
 
-class DocumentTypePageSpec extends PageBehaviours with UserAnswersGenerator {
-
-  private val index         = Index(0)
-  private val documentIndex = Index(0)
+class DocumentTypePageSpec extends PageBehaviours {
 
   "DocumentTypePage" - {
 

--- a/test/pages/behaviours/PageBehaviours.scala
+++ b/test/pages/behaviours/PageBehaviours.scala
@@ -16,6 +16,7 @@
 
 package pages.behaviours
 
+import commonTestUtils.UserAnswersSpecHelper
 import generators.{Generators, UserAnswersGenerator}
 import models.UserAnswers
 import org.scalacheck.Arbitrary.arbitrary
@@ -35,7 +36,8 @@ trait PageBehaviours
     with Generators
     with OptionValues
     with TryValues
-    with UserAnswersGenerator {
+    with UserAnswersGenerator
+    with UserAnswersSpecHelper {
 
   class BeRetrievable[A] {
 

--- a/test/pages/behaviours/PageBehaviours.scala
+++ b/test/pages/behaviours/PageBehaviours.scala
@@ -16,28 +16,18 @@
 
 package pages.behaviours
 
+import base.SpecBase
 import commonTestUtils.UserAnswersSpecHelper
-import generators.{Generators, UserAnswersGenerator}
+import generators.Generators
 import models.UserAnswers
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.{OptionValues, TryValues}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages.QuestionPage
 import play.api.libs.json._
 import queries.AllItemsQuery
 
-trait PageBehaviours
-    extends AnyFreeSpec
-    with Matchers
-    with ScalaCheckPropertyChecks
-    with Generators
-    with OptionValues
-    with TryValues
-    with UserAnswersGenerator
-    with UserAnswersSpecHelper {
+trait PageBehaviours extends SpecBase with ScalaCheckPropertyChecks with Generators with UserAnswersSpecHelper {
 
   class BeRetrievable[A] {
 

--- a/test/pages/preTaskList/DeclarationTypePageSpec.scala
+++ b/test/pages/preTaskList/DeclarationTypePageSpec.scala
@@ -16,7 +16,7 @@
 
 package pages.preTaskList
 
-import models.{DeclarationType, UserAnswers}
+import models.DeclarationType
 import org.scalacheck.Arbitrary.arbitrary
 import pages.behaviours.PageBehaviours
 
@@ -33,9 +33,9 @@ class DeclarationTypePageSpec extends PageBehaviours {
     "cleanup" - {
       "must remove TIRCarnetReferencePage" - {
         "when anything other than Option4 (TIR) selected" in {
-          forAll(arbitrary[UserAnswers], arbitrary[DeclarationType].suchThat(_ != DeclarationType.Option4), arbitrary[String]) {
-            (userAnswers, declarationType, carnetReference) =>
-              val preChange  = userAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
+          forAll(arbitrary[String], arbitrary[DeclarationType].suchThat(_ != DeclarationType.Option4)) {
+            (carnetReference, declarationType) =>
+              val preChange  = emptyUserAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
               val postChange = preChange.set(DeclarationTypePage, declarationType).success.value
 
               postChange.get(TIRCarnetReferencePage) mustNot be(defined)
@@ -45,9 +45,9 @@ class DeclarationTypePageSpec extends PageBehaviours {
 
       "must not remove TIRCarnetReferencePage" - {
         "when Option4 (TIR) selected" in {
-          forAll(arbitrary[UserAnswers], arbitrary[String]) {
-            (userAnswers, carnetReference) =>
-              val preChange  = userAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
+          forAll(arbitrary[String]) {
+            carnetReference =>
+              val preChange  = emptyUserAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
               val postChange = preChange.set(DeclarationTypePage, DeclarationType.Option4).success.value
 
               postChange.get(TIRCarnetReferencePage) must be(defined)

--- a/test/pages/preTaskList/DeclarationTypePageSpec.scala
+++ b/test/pages/preTaskList/DeclarationTypePageSpec.scala
@@ -16,16 +16,11 @@
 
 package pages.preTaskList
 
-import base.SpecBase
-import commonTestUtils.UserAnswersSpecHelper
-import derivable.DeriveNumberOfGuarantees
-import models.{DeclarationType, GuaranteeType, Index}
-import org.scalacheck.Gen
+import models.{DeclarationType, UserAnswers}
+import org.scalacheck.Arbitrary.arbitrary
 import pages.behaviours.PageBehaviours
-import pages.guaranteeDetails.{GuaranteeReferencePage, GuaranteeTypePage}
-import pages.{AccessCodePage, LiabilityAmountPage}
 
-class DeclarationTypeSpec extends PageBehaviours with SpecBase with UserAnswersSpecHelper {
+class DeclarationTypePageSpec extends PageBehaviours {
 
   "DeclarationTypePage" - {
 
@@ -35,76 +30,30 @@ class DeclarationTypeSpec extends PageBehaviours with SpecBase with UserAnswersS
 
     beRemovable[DeclarationType](DeclarationTypePage)
 
-    "Clear down all guarantees if choosing T1,T2 or T2F and Guarantee type B exists" in {
-      val preChangeUserAnswers = emptyUserAnswers
-        .unsafeSetVal(GuaranteeTypePage(Index(0)))(GuaranteeType.TIR)
-        .unsafeSetVal(GuaranteeReferencePage(Index(0)))("REF1")
-        .unsafeSetVal(GuaranteeTypePage(Index(1)))(GuaranteeType.GuaranteeWaiver)
-        .unsafeSetVal(GuaranteeReferencePage(Index(1)))("REF3")
-        .unsafeSetVal(LiabilityAmountPage(Index(1)))("1000")
-        .unsafeSetVal(AccessCodePage(Index(1)))("Star")
-        .unsafeSetVal(GuaranteeTypePage(Index(2)))(GuaranteeType.GuaranteeWaiverByAgreement)
-        .unsafeSetVal(GuaranteeReferencePage(Index(2)))("REF2")
+    "cleanup" - {
+      "must remove TIRCarnetReferencePage" - {
+        "when anything other than Option4 (TIR) selected" in {
+          forAll(arbitrary[UserAnswers], arbitrary[DeclarationType].suchThat(_ != DeclarationType.Option4), arbitrary[String]) {
+            (userAnswers, declarationType, carnetReference) =>
+              val preChange  = userAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
+              val postChange = preChange.set(DeclarationTypePage, declarationType).success.value
 
-      preChangeUserAnswers.get(DeriveNumberOfGuarantees).value mustBe 3
+              postChange.get(TIRCarnetReferencePage) mustNot be(defined)
+          }
+        }
+      }
 
-      val declarationType = Gen.oneOf(DeclarationType.Option1, DeclarationType.Option2, DeclarationType.Option3).sample.value
+      "must not remove TIRCarnetReferencePage" - {
+        "when Option4 (TIR) selected" in {
+          forAll(arbitrary[UserAnswers], arbitrary[String]) {
+            (userAnswers, carnetReference) =>
+              val preChange  = userAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
+              val postChange = preChange.set(DeclarationTypePage, DeclarationType.Option4).success.value
 
-      val userAnswers = preChangeUserAnswers.set(DeclarationTypePage, declarationType).success.value
-
-      userAnswers.get(DeriveNumberOfGuarantees).value mustBe 0
-    }
-
-    "Keep guarantees if choosing T1,T2 or T2F and Guarantee type B exists" in {
-      val preChangeUserAnswers = emptyUserAnswers
-        .unsafeSetVal(GuaranteeTypePage(Index(0)))(GuaranteeType.GuaranteeWaiver)
-        .unsafeSetVal(GuaranteeReferencePage(Index(0)))("REF3")
-        .unsafeSetVal(LiabilityAmountPage(Index(0)))("1000")
-        .unsafeSetVal(AccessCodePage(Index(0)))("Star")
-        .unsafeSetVal(GuaranteeTypePage(Index(1)))(GuaranteeType.GuaranteeWaiverByAgreement)
-        .unsafeSetVal(GuaranteeReferencePage(Index(1)))("REF2")
-
-      preChangeUserAnswers.get(DeriveNumberOfGuarantees).value mustBe 2
-
-      val declarationType = Gen.oneOf(DeclarationType.Option1, DeclarationType.Option2, DeclarationType.Option3).sample.value
-
-      val userAnswers = preChangeUserAnswers.set(DeclarationTypePage, declarationType).success.value
-
-      userAnswers.get(DeriveNumberOfGuarantees).value mustBe 2
-    }
-
-    "Keep guarantees if choosing TIR and Guarantee type B exists" in {
-      val preChangeUserAnswers = emptyUserAnswers
-        .unsafeSetVal(GuaranteeTypePage(Index(0)))(GuaranteeType.TIR)
-        .unsafeSetVal(GuaranteeReferencePage(Index(0)))("REF1")
-        .unsafeSetVal(GuaranteeTypePage(Index(1)))(GuaranteeType.GuaranteeWaiver)
-        .unsafeSetVal(GuaranteeReferencePage(Index(1)))("REF3")
-        .unsafeSetVal(LiabilityAmountPage(Index(1)))("1000")
-        .unsafeSetVal(AccessCodePage(Index(1)))("Star")
-        .unsafeSetVal(GuaranteeTypePage(Index(2)))(GuaranteeType.GuaranteeWaiverByAgreement)
-        .unsafeSetVal(GuaranteeReferencePage(Index(2)))("REF2")
-
-      preChangeUserAnswers.get(DeriveNumberOfGuarantees).value mustBe 3
-
-      val userAnswers = preChangeUserAnswers.set(DeclarationTypePage, DeclarationType.Option4).success.value
-
-      userAnswers.get(DeriveNumberOfGuarantees).value mustBe 3
-    }
-
-    "Remove guarantees if choosing TIR and Guarantee type B doesn't exist" in {
-      val preChangeUserAnswers = emptyUserAnswers
-        .unsafeSetVal(GuaranteeTypePage(Index(0)))(GuaranteeType.GuaranteeWaiver)
-        .unsafeSetVal(GuaranteeReferencePage(Index(0)))("REF3")
-        .unsafeSetVal(LiabilityAmountPage(Index(0)))("1000")
-        .unsafeSetVal(AccessCodePage(Index(0)))("Star")
-        .unsafeSetVal(GuaranteeTypePage(Index(1)))(GuaranteeType.GuaranteeWaiverByAgreement)
-        .unsafeSetVal(GuaranteeReferencePage(Index(1)))("REF2")
-
-      preChangeUserAnswers.get(DeriveNumberOfGuarantees).value mustBe 2
-
-      val userAnswers = preChangeUserAnswers.set(DeclarationTypePage, DeclarationType.Option4).success.value
-
-      userAnswers.get(DeriveNumberOfGuarantees).value mustBe 0
+              postChange.get(TIRCarnetReferencePage) must be(defined)
+          }
+        }
+      }
     }
   }
 }

--- a/test/pages/preTaskList/ProcedureTypePageSpec.scala
+++ b/test/pages/preTaskList/ProcedureTypePageSpec.scala
@@ -16,8 +16,8 @@
 
 package pages.preTaskList
 
+import models.ProcedureType
 import models.ProcedureType._
-import models.{ProcedureType, UserAnswers}
 import org.scalacheck.Arbitrary.arbitrary
 import pages.behaviours.PageBehaviours
 
@@ -35,9 +35,9 @@ class ProcedureTypePageSpec extends PageBehaviours {
 
       "must remove TIRCarnetReferencePage" - {
         "when Simplified selected" in {
-          forAll(arbitrary[UserAnswers], arbitrary[String]) {
-            (userAnswers, carnetReference) =>
-              val preChange  = userAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
+          forAll(arbitrary[String]) {
+            carnetReference =>
+              val preChange  = emptyUserAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
               val postChange = preChange.set(ProcedureTypePage, Simplified).success.value
 
               postChange.get(TIRCarnetReferencePage) mustNot be(defined)
@@ -47,9 +47,9 @@ class ProcedureTypePageSpec extends PageBehaviours {
 
       "must not remove TIRCarnetReferencePage" - {
         "when Normal selected" in {
-          forAll(arbitrary[UserAnswers], arbitrary[String]) {
-            (userAnswers, carnetReference) =>
-              val preChange  = userAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
+          forAll(arbitrary[String]) {
+            carnetReference =>
+              val preChange  = emptyUserAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
               val postChange = preChange.set(ProcedureTypePage, Normal).success.value
 
               postChange.get(TIRCarnetReferencePage) must be(defined)

--- a/test/pages/preTaskList/ProcedureTypePageSpec.scala
+++ b/test/pages/preTaskList/ProcedureTypePageSpec.scala
@@ -20,10 +20,9 @@ import models.ProcedureType._
 import models.{ProcedureType, UserAnswers}
 import org.scalacheck.Arbitrary.arbitrary
 import pages.behaviours.PageBehaviours
-import pages.generalInformation.PreLodgeDeclarationPage
 
-class ProcedureTypeSpec extends PageBehaviours {
-  // format: off
+class ProcedureTypePageSpec extends PageBehaviours {
+
   "ProcedureTypePage" - {
 
     beRetrievable[ProcedureType](ProcedureTypePage)
@@ -33,18 +32,30 @@ class ProcedureTypeSpec extends PageBehaviours {
     beRemovable[ProcedureType](ProcedureTypePage)
 
     "cleanup" - {
-      "must clean down PreLodgedDeclarationPage when changing to Simplified" in {
-        forAll(arbitrary[UserAnswers]) {
-          userAnswers =>
-            val result = userAnswers
-              .set(ProcedureTypePage, Normal).success.value
-              .set(PreLodgeDeclarationPage, true).success.value
-              .set(ProcedureTypePage, Simplified).success.value
 
-            result.get(PreLodgeDeclarationPage) must not be defined
+      "must remove TIRCarnetReferencePage" - {
+        "when Simplified selected" in {
+          forAll(arbitrary[UserAnswers], arbitrary[String]) {
+            (userAnswers, carnetReference) =>
+              val preChange  = userAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
+              val postChange = preChange.set(ProcedureTypePage, Simplified).success.value
+
+              postChange.get(TIRCarnetReferencePage) mustNot be(defined)
+          }
+        }
+      }
+
+      "must not remove TIRCarnetReferencePage" - {
+        "when Normal selected" in {
+          forAll(arbitrary[UserAnswers], arbitrary[String]) {
+            (userAnswers, carnetReference) =>
+              val preChange  = userAnswers.unsafeSetVal(TIRCarnetReferencePage)(carnetReference)
+              val postChange = preChange.set(ProcedureTypePage, Normal).success.value
+
+              postChange.get(TIRCarnetReferencePage) must be(defined)
+          }
         }
       }
     }
   }
-  // format: on
 }

--- a/test/pages/preTaskList/SecurityDetailsTypePageSpec.scala
+++ b/test/pages/preTaskList/SecurityDetailsTypePageSpec.scala
@@ -16,12 +16,10 @@
 
 package pages.preTaskList
 
-import base.SpecBase
-import commonTestUtils.UserAnswersSpecHelper
 import models.SecurityDetailsType
 import pages.behaviours.PageBehaviours
 
-class SecurityDetailsTypePageSpec extends PageBehaviours with SpecBase with UserAnswersSpecHelper {
+class SecurityDetailsTypePageSpec extends PageBehaviours {
 
   "SecurityDetailsTypePage" - {
 

--- a/test/pages/routeDetails/OfficeOfTransitCountryPageSpec.scala
+++ b/test/pages/routeDetails/OfficeOfTransitCountryPageSpec.scala
@@ -16,13 +16,10 @@
 
 package pages.routeDetails
 
-import models.Index
 import models.reference.CountryCode
 import pages.behaviours.PageBehaviours
 
 class OfficeOfTransitCountryPageSpec extends PageBehaviours {
-
-  val index = Index(0)
 
   "OfficeOfTransitCountryPage" - {
 


### PR DESCRIPTION
- CheckMode forces the user back through the journey as an answer change can affect whether the TIR carnet ref. question gets asked or not
- Cleanup of TIRCarnetReferencePage depending on procedure-type and declaration-type answers