### PR TITLE
Fixing flaky test.

### DIFF
--- a/app/views/components/TaskList.scala.html
+++ b/app/views/components/TaskList.scala.html
@@ -33,7 +33,7 @@
                 <li class="app-task-list__item">
                     <span class="app-task-list__task-name">
                         @task.href match {
-                            case Some(href) => { <a href=@href aria-describedby="@task.id-status">@task.name</a> }
+                            case Some(href) => { <a href="@href" aria-describedby="@task.id-status">@task.name</a> }
                             case None       => { @task.name }
                         }
                     </span>


### PR DESCRIPTION
Generated href of `Some("")` was causing the href to capture the aria-describedby instead of being an empty string, for example:
`<a href="aria-describedby=&quot;lUGHAUSlvEyCDNtQXpdViHwizZCccqa2n5vpY0CHs58NkdZW-status&quot;">task.eri</a>`


This caused intermittent test failures. Surrounding @href with quotation marks stops this from happening.