### PR TITLE
Align good item number field length with arrivals (4) and rule G0005 in the DDNTA

### DIFF
--- a/app/controllers/transport/equipment/index/itemNumber/ItemNumberController.scala
+++ b/app/controllers/transport/equipment/index/itemNumber/ItemNumberController.scala
@@ -64,7 +64,13 @@ class ItemNumberController @Inject() (
           formWithErrors => Future.successful(BadRequest(view(formWithErrors, lrn, mode, equipmentIndex, itemNumberIndex))),
           value => {
             implicit val navigator: UserAnswersNavigator = navigatorProvider(mode, equipmentIndex, itemNumberIndex)
-            ItemNumberPage(equipmentIndex, itemNumberIndex).writeToUserAnswers(value).updateTask[TransportDomain]().writeToSession().navigate()
+            ItemNumberPage(equipmentIndex, itemNumberIndex)
+              .writeToUserAnswers(
+                value.replaceFirst("^0+(?!$)", "")
+              )
+              .updateTask[TransportDomain]()
+              .writeToSession()
+              .navigate()
           }
         )
   }

--- a/app/forms/Constants.scala
+++ b/app/forms/Constants.scala
@@ -35,5 +35,5 @@ object Constants {
   lazy val maxAuthorisationRefNumberLength: Int = 35
   lazy val maxContainerIdNumberLength: Int      = 17
   lazy val maxSealIdNumberLength: Int           = 20
-  lazy val itemNumberLength: Int                = 5
+  lazy val itemNumberLength: Int                = 4
 }

--- a/app/forms/Constants.scala
+++ b/app/forms/Constants.scala
@@ -36,4 +36,5 @@ object Constants {
   lazy val maxContainerIdNumberLength: Int      = 17
   lazy val maxSealIdNumberLength: Int           = 20
   lazy val itemNumberLength: Int                = 4
+  lazy val itemNumberMax: Int                   = 1999
 }

--- a/app/forms/ItemNumberFormProvider.scala
+++ b/app/forms/ItemNumberFormProvider.scala
@@ -16,7 +16,7 @@
 
 package forms
 
-import forms.Constants.itemNumberLength
+import forms.Constants.{itemNumberLength, itemNumberMax}
 import forms.mappings.Mappings
 import models.domain.StringFieldRegex.numericRegex
 import play.api.data.Form
@@ -31,7 +31,9 @@ class ItemNumberFormProvider @Inject() extends Mappings {
         .verifying(
           StopOnFirstFail[String](
             maxLength(itemNumberLength, s"$prefix.error.length"),
-            regexp(numericRegex, s"$prefix.error.invalidCharacters")
+            regexp(numericRegex, s"$prefix.error.invalidCharacters"),
+            minimumIntValue(0, s"$prefix.error.range"),
+            maximumIntValue(itemNumberMax, s"$prefix.error.range")
           )
         )
     )

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -56,6 +56,26 @@ trait Constraints {
         }
     }
 
+  protected def maximumIntValue(maximum: Int, errorKey: String): Constraint[String] =
+    Constraint {
+      input =>
+        if (input.toInt <= maximum) {
+          Valid
+        } else {
+          Invalid(errorKey, maximum)
+        }
+    }
+
+  protected def minimumIntValue(min: Int, errorKey: String): Constraint[String] =
+    Constraint {
+      input =>
+        if (input.toInt > min) {
+          Valid
+        } else {
+          Invalid(errorKey, min)
+        }
+    }
+
   protected def inRange[A](itemIndex: A, minimum: A, maximum: A, errorKey: String)(implicit ev: Ordering[A]): Constraint[A] =
     Constraint {
       input =>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1459,7 +1459,7 @@ transport.equipment.index.itemNumber.heading = What is the goods item number?
 transport.equipment.index.itemNumber.hint = This can be up to 4 numbers long.
 transport.equipment.index.itemNumber.checkYourAnswersLabel = Item number
 transport.equipment.index.itemNumber.error.required = Enter the goods item number
-transport.equipment.index.itemNumber.error.length = The goods item number must be 4 characters or less
+transport.equipment.index.itemNumber.error.length = The goods item number must be 4 numbers or less
 transport.equipment.index.itemNumber.error.invalidCharacters = The goods item number must only include numbers 0 to 9
 transport.equipment.index.itemNumber.error.range = The goods item number must be more than 0 and less than 2000
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1456,12 +1456,12 @@ transport.equipment.index.addAnotherSeal.maxLimit.label = You cannot add any mor
 
 transport.equipment.index.itemNumber.title = What is the goods item number?
 transport.equipment.index.itemNumber.heading = What is the goods item number?
-transport.equipment.index.itemNumber.hint = This will be up to 4 digits long, for example 1999.
+transport.equipment.index.itemNumber.hint = This can be up to 4 numbers long.
 transport.equipment.index.itemNumber.checkYourAnswersLabel = Item number
 transport.equipment.index.itemNumber.error.required = Enter the goods item number
-transport.equipment.index.itemNumber.error.length = The goods item number must be 4 digits or less
+transport.equipment.index.itemNumber.error.length = The goods item number must be 4 characters or less
 transport.equipment.index.itemNumber.error.invalidCharacters = The goods item number must only include numbers 0 to 9
-transport.equipment.index.itemNumber.error.range = The goods item number must be greater than zero and less than 2000
+transport.equipment.index.itemNumber.error.range = The goods item number must be more than 0 and less than 2000
 
 transport.equipment.index.addGoodsItemNumberYesNo.title = Do you want to add a goods item number?
 transport.equipment.index.addGoodsItemNumberYesNo.heading = Do you want to add a goods item number?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1456,11 +1456,12 @@ transport.equipment.index.addAnotherSeal.maxLimit.label = You cannot add any mor
 
 transport.equipment.index.itemNumber.title = What is the goods item number?
 transport.equipment.index.itemNumber.heading = What is the goods item number?
-transport.equipment.index.itemNumber.hint = This will be up to 4 characters long, for example 1999.
+transport.equipment.index.itemNumber.hint = This will be up to 4 digits long, for example 1999.
 transport.equipment.index.itemNumber.checkYourAnswersLabel = Item number
 transport.equipment.index.itemNumber.error.required = Enter the goods item number
-transport.equipment.index.itemNumber.error.length = The goods item number must be 4 characters or less
+transport.equipment.index.itemNumber.error.length = The goods item number must be 4 digits or less
 transport.equipment.index.itemNumber.error.invalidCharacters = The goods item number must only include numbers 0 to 9
+transport.equipment.index.itemNumber.error.range = The goods item number must be greater than zero and less than 2000
 
 transport.equipment.index.addGoodsItemNumberYesNo.title = Do you want to add a goods item number?
 transport.equipment.index.addGoodsItemNumberYesNo.heading = Do you want to add a goods item number?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1456,7 +1456,7 @@ transport.equipment.index.addAnotherSeal.maxLimit.label = You cannot add any mor
 
 transport.equipment.index.itemNumber.title = What is the goods item number?
 transport.equipment.index.itemNumber.heading = What is the goods item number?
-transport.equipment.index.itemNumber.hint = This will be 4 characters long, for example 1234.
+transport.equipment.index.itemNumber.hint = This will be up to 4 characters long, for example 1999.
 transport.equipment.index.itemNumber.checkYourAnswersLabel = Item number
 transport.equipment.index.itemNumber.error.required = Enter the goods item number
 transport.equipment.index.itemNumber.error.length = The goods item number must be 4 characters or less

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1456,10 +1456,10 @@ transport.equipment.index.addAnotherSeal.maxLimit.label = You cannot add any mor
 
 transport.equipment.index.itemNumber.title = What is the goods item number?
 transport.equipment.index.itemNumber.heading = What is the goods item number?
-transport.equipment.index.itemNumber.hint = This can be up to 5 numbers long.
+transport.equipment.index.itemNumber.hint = This will be 4 characters long, for example 1234.
 transport.equipment.index.itemNumber.checkYourAnswersLabel = Item number
 transport.equipment.index.itemNumber.error.required = Enter the goods item number
-transport.equipment.index.itemNumber.error.length = The goods item number must be 5 characters or less
+transport.equipment.index.itemNumber.error.length = The goods item number must be 4 characters or less
 transport.equipment.index.itemNumber.error.invalidCharacters = The goods item number must only include numbers 0 to 9
 
 transport.equipment.index.addGoodsItemNumberYesNo.title = Do you want to add a goods item number?

--- a/test/controllers/transport/equipment/index/itemNumber/ItemNumberControllerSpec.scala
+++ b/test/controllers/transport/equipment/index/itemNumber/ItemNumberControllerSpec.scala
@@ -37,7 +37,7 @@ class ItemNumberControllerSpec extends SpecBase with AppWithDefaultMockFixtures 
   private val form                 = formProvider("transport.equipment.index.itemNumber")
   private val mode                 = NormalMode
   private lazy val itemNumberRoute = routes.ItemNumberController.onPageLoad(lrn, mode, equipmentIndex, itemNumberIndex).url
-  private val validAnswer          = "12345"
+  private val validAnswer          = "1234"
 
   override def guiceApplicationBuilder(): GuiceApplicationBuilder =
     super

--- a/test/data/injectableCacheDataForTesting.json
+++ b/test/data/injectableCacheDataForTesting.json
@@ -116,6 +116,7 @@
             "id" : "XI000142",
             "name" : "Belfast EPU",
             "phoneNumber" : "+44 (0)02896 931537"
+            "phoneNumber" : "+44 (0)02896 931537"
           }
         }
       },

--- a/test/data/injectableCacheDataForTesting.json
+++ b/test/data/injectableCacheDataForTesting.json
@@ -116,7 +116,6 @@
             "id" : "XI000142",
             "name" : "Belfast EPU",
             "phoneNumber" : "+44 (0)02896 931537"
-            "phoneNumber" : "+44 (0)02896 931537"
           }
         }
       },

--- a/test/forms/ItemNumberFormProviderSpec.scala
+++ b/test/forms/ItemNumberFormProviderSpec.scala
@@ -20,12 +20,18 @@ import forms.behaviours.StringFieldBehaviours
 import org.scalacheck.Gen
 import play.api.data.FormError
 
+import scala.collection.immutable.ArraySeq
+
 class ItemNumberFormProviderSpec extends StringFieldBehaviours {
 
   private val prefix = Gen.alphaNumStr.sample.value
   val requiredKey    = s"$prefix.error.required"
   val lengthKey      = s"$prefix.error.length"
+  val rangeKey       = s"$prefix.error.range"
   val maxLength      = 4
+  val maxLengthValue = 9999
+  val maxValue       = 1999
+  val minValue       = 1
 
   val form = new ItemNumberFormProvider()(prefix)
 
@@ -51,6 +57,21 @@ class ItemNumberFormProviderSpec extends StringFieldBehaviours {
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like stringFieldWithMaximumIntValue(
+      form,
+      fieldName,
+      maxValue,
+      maxLengthValue,
+      FormError(fieldName, rangeKey, ArraySeq(maxValue))
+    )
+
+    behave like stringFieldWithMinimumIntValue(
+      form,
+      fieldName,
+      minValue,
+      FormError(fieldName, rangeKey, ArraySeq(minValue - 1))
     )
 
     "when value breaks multiple validation rules" - {

--- a/test/forms/ItemNumberFormProviderSpec.scala
+++ b/test/forms/ItemNumberFormProviderSpec.scala
@@ -25,7 +25,7 @@ class ItemNumberFormProviderSpec extends StringFieldBehaviours {
   private val prefix = Gen.alphaNumStr.sample.value
   val requiredKey    = s"$prefix.error.required"
   val lengthKey      = s"$prefix.error.length"
-  val maxLength      = 5
+  val maxLength      = 4
 
   val form = new ItemNumberFormProvider()(prefix)
 

--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -81,4 +81,19 @@ trait StringFieldBehaviours extends FieldBehaviours {
     }
   }
 
+  def stringFieldWithMaximumIntValue(form: Form[_], fieldName: String, max: Int, fieldMax: Int, expectedError: FormError): Unit =
+    s"must not bind values > $max and < $max" in {
+      forAll(positiveIntsMinMax(max, fieldMax)) {
+        number =>
+          val result = form.bind(Map(fieldName -> number.toString)).apply(fieldName)
+          result.errors mustEqual Seq(expectedError)
+      }
+    }
+
+  def stringFieldWithMinimumIntValue(form: Form[_], fieldName: String, min: Int, expectedError: FormError): Unit =
+    s"must not bind values < $min" in {
+      val testCase = min - 1
+      val result   = form.bind(Map(fieldName -> testCase.toString)).apply(fieldName)
+      result.errors mustEqual Seq(expectedError)
+    }
 }

--- a/test/generators/Generators.scala
+++ b/test/generators/Generators.scala
@@ -100,6 +100,8 @@ trait Generators extends UserAnswersGenerator with ModelGenerators with ViewMode
 
   def positiveInts: Gen[Int] = Gen.choose(0, Int.MaxValue)
 
+  def positiveIntsMinMax(min: Int, max: Int): Gen[Int] = Gen.choose(min, max)
+
   def intsOutsideRange(min: Int, max: Int): Gen[Int] =
     arbitrary[Int] retryUntil (
       x => x < min || x > max

--- a/test/views/transport/equipment/index/itemNumber/ItemNumberViewSpec.scala
+++ b/test/views/transport/equipment/index/itemNumber/ItemNumberViewSpec.scala
@@ -44,7 +44,7 @@ class ItemNumberViewSpec extends InputTextViewBehaviours[String] {
 
   behave like pageWithHeading()
 
-  behave like pageWithHint("This will be up to 4 characters long, for example 1999.")
+  behave like pageWithHint("This can be up to 4 numbers long.")
 
   behave like pageWithInputText(Some(InputSize.Width20))
 

--- a/test/views/transport/equipment/index/itemNumber/ItemNumberViewSpec.scala
+++ b/test/views/transport/equipment/index/itemNumber/ItemNumberViewSpec.scala
@@ -44,7 +44,7 @@ class ItemNumberViewSpec extends InputTextViewBehaviours[String] {
 
   behave like pageWithHeading()
 
-  behave like pageWithHint("This can be up to 5 numbers long.")
+  behave like pageWithHint("This will be 4 characters long, for example 1234.")
 
   behave like pageWithInputText(Some(InputSize.Width20))
 

--- a/test/views/transport/equipment/index/itemNumber/ItemNumberViewSpec.scala
+++ b/test/views/transport/equipment/index/itemNumber/ItemNumberViewSpec.scala
@@ -44,7 +44,7 @@ class ItemNumberViewSpec extends InputTextViewBehaviours[String] {
 
   behave like pageWithHeading()
 
-  behave like pageWithHint("This will be 4 characters long, for example 1234.")
+  behave like pageWithHint("This will be up to 4 characters long, for example 1999.")
 
   behave like pageWithInputText(Some(InputSize.Width20))
 


### PR DESCRIPTION
![Screenshot 2023-02-02 at 16 48 23](https://user-images.githubusercontent.com/40767309/217195874-0bb2a0e1-aed3-49c8-8eb8-e7bf65792c3f.png)

Screenshot shows a positive integer in the range 1-1999. 

The code has been updated accordingly. 

Also updated the content as per https://docs.google.com/document/d/1Hu2tcA-612ZzTugrwdB9R_fiB09gh_Te/edit