### PR TITLE
CTCP-3415 CTCP-3415 | Correct log levels

### DIFF
--- a/app/connectors/EnrolmentStoreConnector.scala
+++ b/app/connectors/EnrolmentStoreConnector.scala
@@ -42,7 +42,7 @@ class EnrolmentStoreConnector @Inject() (val config: FrontendAppConfig, val http
         }
     } recover {
       case exception =>
-        logger.info("[EnrolmentStoreProxyConnector][checkSaGroup] Enrolment Store Proxy error", exception)
+        logger.warn("[EnrolmentStoreProxyConnector][checkSaGroup] Enrolment Store Proxy error", exception)
         false
     }
   }

--- a/app/controllers/TaskListController.scala
+++ b/app/controllers/TaskListController.scala
@@ -67,7 +67,7 @@ class TaskListController @Inject() (
             logger.warn(s"TaskListController:onSubmit: bad request: ${response.status}: ${response.body}")
             BadRequest(response.body)
           case e =>
-            logger.warn(s"TaskListController:onSubmit: something went wrong: ${e.status}-${e.body}")
+            logger.error(s"TaskListController:onSubmit: something went wrong: ${e.status}-${e.body}")
             InternalServerError(e.body)
         }
     }


### PR DESCRIPTION
Use the appropriate log level

Error - for significant issues that you will cause someone to be woken up at night to fix, such as inability to perform the service's central responsibility. These should very rarely happen. An example is an OutOfMemoryError or IO error.

Warn - for significant issues that will get someone's attention. Examples include unexpected data returned from a dependent service.

Info - general information useful to someone monitoring the service, such as you do after a deploy. Examples include payload.

Debug - detailed information from internal methods used for developers. This must be switched off in Production and Staging.