### PR TITLE
CTCP-4474: Updating sass.

### DIFF
--- a/app/assets/stylesheets/application-ie8.scss
+++ b/app/assets/stylesheets/application-ie8.scss
@@ -1,8 +1,0 @@
-$govuk-assets-path: "/manage-transit-movements/departures/assets/lib/govuk-frontend/govuk/assets/";
-$hmrc-assets-path: "/manage-transit-movements/departures/assets/lib/hmrc-frontend/hmrc/assets/";
-
-@import "lib/govuk-frontend/govuk/all-ie8.scss";
-@import "lib/hmrc-frontend/hmrc/all-ie8.scss";
-
-@import "partials/shame";
-@import "partials/task-list";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,8 +1,5 @@
-$govuk-assets-path: "/manage-transit-movements/departures/assets/lib/govuk-frontend/govuk/assets/";
-$hmrc-assets-path: "/manage-transit-movements/departures/assets/lib/hmrc-frontend/hmrc/assets/";
-
-@import "lib/govuk-frontend/govuk/all";
-@import "lib/hmrc-frontend/hmrc/all";
+$govuk-include-default-font-face: false;
+@import "lib/govuk-frontend/govuk/base";
 
 @import "partials/shame";
 @import "partials/task-list";

--- a/app/assets/stylesheets/partials/_shame.scss
+++ b/app/assets/stylesheets/partials/_shame.scss
@@ -25,28 +25,6 @@
     display: inline-block;
 }
 
-// ******************************************************
-// ******************************************************
-// add-to-a-list pattern
-// remove set widths to favour action links
-// ******************************************************
-// ******************************************************
-.ctc-add-to-a-list .govuk-summary-list__key,
-.ctc-add-to-a-list .govuk-summary-list__value {
-    width: auto;
-}
-.ctc-add-to-a-list .govuk-summary-list__actions {
-    width: 40%;
-}
-.ctc-add-to-a-list .govuk-summary-list__key,
-.ctc-add-to-a-list .govuk-summary-list__value {
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    hyphens: auto;
-}
-
-
-
 // make numbers easier to read
 @supports (font-variant-numeric: tabular-nums) {
     table,


### PR DESCRIPTION
- https://github.com/hmrc/play-frontend-hmrc/blob/3cbd82d8ad2952b6310867d25eb5cc171bc16cae/docs/maintainers/sass-compilation.md
- application-ie8.scss removed ahead of govuk-frontend 5.0.0 release
- Removing unused `ctc-add-to-a-list` styling