### PR TITLE
CTCP-5498: Passing Accept header in requests where necessary.

### DIFF
--- a/app/config/PhaseConfig.scala
+++ b/app/config/PhaseConfig.scala
@@ -16,14 +16,36 @@
 
 package config
 
+import com.typesafe.config.Config
+import config.PhaseConfig.Values
+import play.api.{ConfigLoader, Configuration}
+
+import javax.inject.Inject
+
 trait PhaseConfig {
-  val apiVersionHeader: String
+  val values: Values
 }
 
-class TransitionConfig() extends PhaseConfig {
-  override val apiVersionHeader: String = "transitional"
-}
+object PhaseConfig {
 
-class PostTransitionConfig() extends PhaseConfig {
-  override val apiVersionHeader: String = "final"
+  class TransitionConfig @Inject() (configuration: Configuration) extends PhaseConfig {
+    override val values: Values = configuration.get[Values]("phase.transitional")
+  }
+
+  class PostTransitionConfig @Inject() (configuration: Configuration) extends PhaseConfig {
+    override val values: Values = configuration.get[Values]("phase.final")
+  }
+
+  case class Values(name: String, apiVersion: Double)
+
+  object Values {
+
+    implicit val configLoader: ConfigLoader[Values] = (config: Config, path: String) =>
+      config.getConfig(path) match {
+        case phase =>
+          val name       = phase.getString("name")
+          val apiVersion = phase.getDouble("apiVersion")
+          Values(name, apiVersion)
+      }
+  }
 }

--- a/app/config/PostTransitionModule.scala
+++ b/app/config/PostTransitionModule.scala
@@ -16,6 +16,8 @@
 
 package config
 
+import config.PhaseConfig.PostTransitionConfig
+
 class PostTransitionModule extends Module {
 
   override def configure(): Unit = {

--- a/app/config/TransitionModule.scala
+++ b/app/config/TransitionModule.scala
@@ -16,6 +16,8 @@
 
 package config
 
+import config.PhaseConfig.TransitionConfig
+
 class TransitionModule extends Module {
 
   override def configure(): Unit = {

--- a/app/connectors/CacheConnector.scala
+++ b/app/connectors/CacheConnector.scala
@@ -20,6 +20,7 @@ import config.{FrontendAppConfig, PhaseConfig}
 import models.LockCheck._
 import models.{DepartureMessages, LocalReferenceNumber, LockCheck, UserAnswers}
 import play.api.Logging
+import play.api.http.HeaderNames._
 import play.api.http.Status._
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.HttpReads.Implicits._
@@ -38,7 +39,12 @@ class CacheConnector @Inject() (
 
   private val baseUrl = s"${config.cacheUrl}"
 
-  private val apiVersionHeader = "APIVersion" -> phaseConfig.apiVersionHeader
+  private val apiVersionHeader = "APIVersion" -> phaseConfig.values.name
+
+  private val acceptHeader = ACCEPT -> {
+    val version = phaseConfig.values.apiVersion
+    s"application/vnd.hmrc.$version+json"
+  }
 
   def get(lrn: LocalReferenceNumber)(implicit hc: HeaderCarrier): Future[Option[UserAnswers]] = {
     val url = url"$baseUrl/user-answers/$lrn"
@@ -103,7 +109,7 @@ class CacheConnector @Inject() (
     val url = url"$baseUrl/declaration/submit"
     http
       .post(url)
-      .setHeader(apiVersionHeader)
+      .setHeader(apiVersionHeader, acceptHeader)
       .withBody(Json.toJson(lrn))
       .execute[HttpResponse]
   }
@@ -112,7 +118,7 @@ class CacheConnector @Inject() (
     val url = url"$baseUrl/declaration/submit-amendment"
     http
       .post(url)
-      .setHeader(apiVersionHeader)
+      .setHeader(apiVersionHeader, acceptHeader)
       .withBody(Json.toJson(lrn))
       .execute[HttpResponse]
   }
@@ -129,6 +135,7 @@ class CacheConnector @Inject() (
     val url = url"$baseUrl/messages/$lrn"
     http
       .get(url)
+      .setHeader(acceptHeader)
       .execute[DepartureMessages]
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -129,3 +129,15 @@ enrolment {
 host = "http://localhost:10120"
 
 accessibility-statement.service-path = "/manage-transit-movements-p5"
+
+phase {
+  transitional {
+    name = "transitional"
+    apiVersion = 2.0
+  }
+
+  final {
+    name = "final"
+    apiVersion = 2.1
+  }
+}

--- a/it/test/connectors/CacheConnectorSpec.scala
+++ b/it/test/connectors/CacheConnectorSpec.scala
@@ -236,6 +236,7 @@ class CacheConnectorSpec extends ItSpecBase with WireMockServerHandler with Scal
         server.stubFor(
           post(urlEqualTo(url))
             .withHeader("APIVersion", equalTo("transitional"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
             .willReturn(aResponse().withStatus(OK))
         )
 
@@ -250,6 +251,7 @@ class CacheConnectorSpec extends ItSpecBase with WireMockServerHandler with Scal
         server.stubFor(
           post(urlEqualTo(url))
             .withHeader("APIVersion", equalTo("transitional"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
             .willReturn(aResponse().withStatus(status))
         )
 
@@ -264,6 +266,7 @@ class CacheConnectorSpec extends ItSpecBase with WireMockServerHandler with Scal
         server.stubFor(
           post(urlEqualTo(url))
             .withHeader("APIVersion", equalTo("transitional"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
             .willReturn(aResponse().withStatus(status))
         )
 
@@ -281,6 +284,7 @@ class CacheConnectorSpec extends ItSpecBase with WireMockServerHandler with Scal
         server.stubFor(
           post(urlEqualTo(url))
             .withHeader("APIVersion", equalTo("transitional"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
             .willReturn(aResponse().withStatus(OK))
         )
 
@@ -295,6 +299,7 @@ class CacheConnectorSpec extends ItSpecBase with WireMockServerHandler with Scal
         server.stubFor(
           post(urlEqualTo(url))
             .withHeader("APIVersion", equalTo("transitional"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
             .willReturn(aResponse().withStatus(status))
         )
 
@@ -309,6 +314,7 @@ class CacheConnectorSpec extends ItSpecBase with WireMockServerHandler with Scal
         server.stubFor(
           post(urlEqualTo(url))
             .withHeader("APIVersion", equalTo("transitional"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
             .willReturn(aResponse().withStatus(status))
         )
 
@@ -358,6 +364,7 @@ class CacheConnectorSpec extends ItSpecBase with WireMockServerHandler with Scal
       "must return messages when status is Ok" in {
         server.stubFor(
           get(urlEqualTo(url))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
             .willReturn(okJson(json))
         )
 
@@ -377,6 +384,7 @@ class CacheConnectorSpec extends ItSpecBase with WireMockServerHandler with Scal
           status =>
             server.stubFor(
               get(urlEqualTo(url))
+                .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
                 .willReturn(aResponse.withStatus(status))
             )
 


### PR DESCRIPTION
Once this and https://github.com/hmrc/manage-transit-movements-departure-cache/pull/136 have been deployed, the APIVersion header can be removed.